### PR TITLE
Fix: XML parser & WebKit

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,3 +1,4 @@
+var matchAll = require('string.prototype.matchall');
 var NAMESPACE = require("./conventions").NAMESPACE;
 
 //[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
@@ -83,7 +84,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 		}
 	}
 	function position(p,m){
-		while(p>=lineEnd && (m = linePattern.exec(source))){
+		while(p>=lineEnd && (m = matches[locator.lineNumber])) {
 			lineStart = m.index;
 			lineEnd = lineStart + m[0].length;
 			locator.lineNumber++;
@@ -93,7 +94,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	}
 	var lineStart = 0;
 	var lineEnd = 0;
-	var linePattern = /.*(?:\r\n?|\n)|.*$/g
+	var matches = [...matchAll(source, /.*(?:\r\n?|\n)|.*$/g)];
 	var locator = domBuilder.locator;
 
 	var parseStack = [{currentNSMap:defaultNSMapCopy}]

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "engines": {
     "node": ">=10.0.0"
   },
-  "dependencies": {},
+  "dependencies": { "string.prototype.matchall": "3.0.1" },
   "devDependencies": {
     "@stryker-mutator/core": "^5.2.2",
     "eslint": "^7.32.0",


### PR DESCRIPTION
Applying the same parser fix that we did in the older xmldom library:

https://github.com/Instawork/xmldom/pull/1

Quote from that PR:
```
Replace usage of Regex.prototype.exec with shim of Regex.prototype.matchAll. This suppress the bug faced with certain versions of WebKit where the inner state of the regex would be lost and iteration would restart at the beginning of the string. Tested with Android 7.

https://app.asana.com/0/244065166232575/1129162278755512/f
```